### PR TITLE
Improve tf_to_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Converts *tf* transforms to odometry messages.<br>
 Allows two-phase transform lookup with the root using latest transform without waiting.
 This is useful e.g. for fast *map*-to-*base_link* odometry from slow *map*-to-*odom* transforms.
 
+## `tf_to_path`
+Converts *tf* transforms to path messages.<br>
+Allows out-of-order transform messages to come and adds older measurements to the correct
+place in the path. The individual path points are looked up at times when the `stamp_trigger_frame`
+frame is updated on the `tf_msg` topic (the idea is that points on the path have the very same timestamps as
+your robot's odometry). Do not forget to remap `tf_msg` to the actual TF topic. `stamp_trigger_frame`
+is by default the same as `child_frame`, but you have to set it different e.g. if your `child_frame`
+is a static transform to the actual top-level body link.
+
 ## `tf_fast_repeater`
 Use this if a transform you have needs to be republished on a higher frequency
 always with current timestamp (to allow constant extrapolation of the transform).

--- a/include/nav_utils/tf_to_path.h
+++ b/include/nav_utils/tf_to_path.h
@@ -55,6 +55,7 @@ private:
   std::string child_frame_;
   std::string stamp_trigger_frame_;
   bool        recompute_whole_path_;
+  bool        prune_trajectory_;
 
   std::mutex                           mutex_trajectory_;
   std::set<time_point, time_point_cmp> trajectory_;  // Ordered set by time

--- a/include/nav_utils/tf_to_path.h
+++ b/include/nav_utils/tf_to_path.h
@@ -54,6 +54,7 @@ private:
   std::string parent_frame_;
   std::string child_frame_;
   std::string stamp_trigger_frame_;
+  bool        recompute_whole_path_;
 
   std::mutex                           mutex_trajectory_;
   std::set<time_point, time_point_cmp> trajectory_;  // Ordered set by time

--- a/include/nav_utils/tf_to_path.h
+++ b/include/nav_utils/tf_to_path.h
@@ -53,6 +53,7 @@ private:
 
   std::string parent_frame_;
   std::string child_frame_;
+  std::string stamp_trigger_frame_;
 
   std::mutex                           mutex_trajectory_;
   std::set<time_point, time_point_cmp> trajectory_;  // Ordered set by time
@@ -62,15 +63,9 @@ private:
 
   int sub_queue_size_;
 
-  int prev_path_size_ = 0;
+  nav_msgs::Path prev_path_;
 
 public:
   TransformToPath(ros::NodeHandle &nh, ros::NodeHandle &pnh);
-
-  /* std_msgs::Header    extract_header(const topic_tools::ShapeShifter &msg); */
-  /* geometry_msgs::Pose lookupPose(const ros::Time &stamp, const std::string &child_frame); */
-  /* void                publishMessages(const ros::Time &stamp, const std::string &child_frame); */
-  /* void                triggerReceived(const topic_tools::ShapeShifter &msg); */
-  /* void                timerCallback(const ros::TimerEvent &event); */
 };
 }  // namespace nav_utils

--- a/include/nav_utils/tf_to_path.h
+++ b/include/nav_utils/tf_to_path.h
@@ -17,7 +17,12 @@
 #include <mutex>
 #include <set>
 
-using time_point = std::pair<double, geometry_msgs::Point>;
+struct time_point
+{
+  double first;
+  mutable geometry_msgs::Point second;
+};
+
 struct time_point_cmp
 {
   bool operator()(const time_point &lhs, const time_point &rhs) const {


### PR DESCRIPTION
Several improvements. See commit messages for description.

Main improvement is adding delayed resolution of TFs in case their lookup takes longer than is the update rate. Such TFs will be stored with NaN in their coordinates and a timeout-less lookup will be used to resolve them on every update.